### PR TITLE
Add unrated label to profile

### DIFF
--- a/components/ProfileInfo.vue
+++ b/components/ProfileInfo.vue
@@ -121,6 +121,11 @@ export default {
       return name.replace(' ', '<br />')
     },
     ratingText() {
+      
+      if (this.rating <= 0) {
+        return 'Unrated'
+      }
+
       if (this.rating <= 33) {
         return 'Bronze'
       }


### PR DESCRIPTION
Adds an if condition to check if score is 0, to display an "Unrated" label in the profile.